### PR TITLE
Fix wrongly typed jsdoc

### DIFF
--- a/chunked-file-reader.js
+++ b/chunked-file-reader.js
@@ -71,7 +71,7 @@
      * </ul>
      *
      * @method readChunks
-     * @param input {blob} The Blob (File) object
+     * @param input {Blob} The Blob (File) object
      */
     ChunkedFileReader.prototype.readChunks= function(input){
         var chunkSize= Math.min(this.maxChunkSize, input.size);


### PR DESCRIPTION
The incorrect case was making this incompatible with Typescript consumers, as there is no `blob` type (but there is a `Blob` !)